### PR TITLE
Exporting IntermediateValue Types

### DIFF
--- a/src/Genetic.elm
+++ b/src/Genetic.elm
@@ -1,4 +1,4 @@
-module Genetic exposing (IntermediateValue, Method(..), Options, dnaFromValue, executeInitialStep, executeStep, numGenerationsFromValue, solutionGenerator)
+module Genetic exposing (IntermediateValue(..), Method(..), Options, dnaFromValue, executeInitialStep, executeStep, numGenerationsFromValue, solutionGenerator)
 
 {-| An implementation of a [genetic algorithm](https://www.infoq.com/presentations/genetic-algorithms?utm_source=infoq&utm_medium=videos_homepage&utm_campaign=videos_row1). A single function `solutionGenerator` is exposed which will
 produce a generator that can be used to evolve a "good enough" solution.


### PR DESCRIPTION
I've encountered an issue when trying to use IntermediateValue and its 'tags', these being (Population dna) (PointedDna dna) Int.
The following error message appeared at build:

```
Cannot find pattern `IntermediateValue`
134| updateSolution newFitness ( IntermediateValue p pd ng, seed )
```

With the change I did, it gets [fixed.](https://github.com/elm-lang/elm-lang.org/issues/523)